### PR TITLE
Adds "cross-env" to be compatible with other OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,46 +1,47 @@
 {
-  "name": "payload-nextjs-server",
-  "description": "A boilerplate project for NextJS with Payload CMS",
-  "keywords": [
-    "payload",
-    "cms",
-    "nextjs"
-  ],
-  "version": "0.0.1",
-  "private": false,
-  "author": "TRBL",
-  "scripts": {
-    "build:next": "next build",
-    "build:server": "tsc --project tsconfig.server.json",
-    "build:payload": "payload build",
-    "build": "NODE_ENV=production yarn build:payload && yarn build:server && NEXT_BUILD=true node dist/index.js",
-    "dev": "node dev.js",
-    "seed": "node seed/index.js",
-    "serve": "NODE_ENV=production node dist/index.js"
-  },
-  "dependencies": {
-    "@babel/register": "^7.12.10",
-    "dotenv": "^8.2.0",
-    "express": "^4.17.1",
-    "next": "^10.0.5",
-    "payload": "^0.6.5",
-    "react": "^17.0.1",
-    "typescript": "^4.1.3"
-  },
-  "devDependencies": {
-    "@trbl/eslint-config": "^1.2.4",
-    "@types/express": "^4.17.11",
-    "@types/react": "^16.9.56",
-    "@typescript-eslint/eslint-plugin": "4.0.1",
-    "@typescript-eslint/parser": "4.0.1",
-    "eslint": "^7.11.0",
-    "eslint-plugin-import": "^2.20.0",
-    "eslint-plugin-jest": "^23.16.0",
-    "eslint-plugin-jest-dom": "^3.0.1",
-    "eslint-plugin-jsx-a11y": "^6.2.1",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-react": "^7.18.0",
-    "eslint-plugin-react-hooks": "^2.3.0",
-    "ts-node": "^9.1.1"
-  }
+    "name": "payload-nextjs-server",
+    "description": "A boilerplate project for NextJS with Payload CMS",
+    "keywords": [
+        "payload",
+        "cms",
+        "nextjs"
+    ],
+    "version": "0.0.1",
+    "private": false,
+    "author": "TRBL",
+    "scripts": {
+        "build:next": "next build",
+        "build:server": "tsc --project tsconfig.server.json",
+        "build:payload": "payload build",
+        "build": "cross-env NODE_ENV=production yarn build:payload && yarn build:server && cross-env NEXT_BUILD=true node dist/index.js",
+        "dev": "node server/index.js",
+        "seed": "node seed/index.js",
+        "serve": "cross-env NODE_ENV=production node dist/index.js"
+    },
+    "dependencies": {
+        "@babel/register": "^7.12.10",
+        "cross-env": "^7.0.3",
+        "dotenv": "^8.2.0",
+        "express": "^4.17.1",
+        "next": "^10.0.5",
+        "payload": "^0.6.5",
+        "react": "^17.0.1",
+        "typescript": "^4.1.3"
+    },
+    "devDependencies": {
+        "@trbl/eslint-config": "^1.2.4",
+        "@types/express": "^4.17.11",
+        "@types/react": "^16.9.56",
+        "@typescript-eslint/eslint-plugin": "4.0.1",
+        "@typescript-eslint/parser": "4.0.1",
+        "eslint": "^7.11.0",
+        "eslint-plugin-import": "^2.20.0",
+        "eslint-plugin-jest": "^23.16.0",
+        "eslint-plugin-jest-dom": "^3.0.1",
+        "eslint-plugin-jsx-a11y": "^6.2.1",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-react": "^7.18.0",
+        "eslint-plugin-react-hooks": "^2.3.0",
+        "ts-node": "^9.1.1"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,6 +3964,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
@@ -3982,7 +3989,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Windows is unable to recognize "NODE_ENV" without the help of cross-env.

Closes #7