### PR TITLE
Fix slate version at 0.81.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "payload": "^1.0.7",
     "react": "^18.1.0",
     "sass": "^1.52.0",
-    "slate": "^0.81.0",
+    "slate": "0.81.1",
     "typescript": "^4.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Slate (slate-react) v0.82 has a change in it which breaks page editing in payloadcms. This change fixes the slate version at 0.81.1 which is known to work.

https://github.com/ianstormtaylor/slate/releases

Additional info on Discord at https://discord.com/channels/967097582721572934/1013930465570336818/1015397735282790450 