### PR TITLE
fix: adjusts build script for static sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "TRBL",
   "scripts": {
-    "build:next": "cross-env NEXT_BUILD=1 yarn serve",
+    "build:next": "next build",
     "build:server": "tsc --project tsconfig.server.json",
     "build:payload": "payload build",
     "copyfiles:media": "copyfiles -u 1 media/**/*.{svg,jpg,png} dist/media",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "TRBL",
   "scripts": {
-    "build:next": "next build",
+    "build:next": "cross-env NEXT_BUILD=1 yarn serve",
     "build:server": "tsc --project tsconfig.server.json",
     "build:payload": "payload build",
     "copyfiles:media": "copyfiles -u 1 media/**/*.{svg,jpg,png} dist/media",

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import payload from 'payload';
 import { GetServerSideProps } from 'next';
 import getConfig from 'next/config';
 import { Type as PageType } from '../collections/Page';
@@ -7,6 +6,7 @@ import NotFound from '../components/NotFound';
 import Head from '../components/Head';
 import classes from '../css/page.module.css';
 import RenderBlocks from '../components/RenderBlocks';
+import getPayloadClient from '../payloadClient';
 
 const { publicRuntimeConfig: { SERVER_URL } } = getConfig();
 
@@ -61,6 +61,8 @@ export default Page;
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const slug = ctx.params?.slug ? (ctx.params.slug as string[]).join('/') : 'home';
+
+  const payload = await getPayloadClient();
 
   const pageQuery = await payload.find({
     collection: 'pages',

--- a/payloadClient.ts
+++ b/payloadClient.ts
@@ -1,0 +1,51 @@
+import { getPayload } from 'payload/dist/payload';
+import { Payload } from 'payload';
+import config from './payload.config';
+
+if (!process.env.MONGODB_URI) {
+  throw new Error('MONGODB_URI environment variable is missing');
+}
+
+if (!process.env.PAYLOAD_SECRET) {
+  throw new Error('PAYLOAD_SECRET environment variable is missing');
+}
+
+/**
+ * Global is used here to maintain a cached connection across hot reloads
+ * in development. This prevents connections growing exponentially
+ * during API Route usage.
+ *
+ * Source: https://github.com/vercel/next.js/blob/canary/examples/with-mongodb-mongoose/lib/dbConnect.js
+ */
+let cached = (global as any).payload;
+
+if (!cached) {
+  // eslint-disable-next-line no-multi-assign
+  cached = (global as any).payload = { client: null, promise: null };
+}
+
+export const getPayloadClient = async (): Promise<Payload> => {
+  if (cached.client) {
+    return cached.client;
+  }
+
+  if (!cached.promise) {
+    cached.promise = await getPayload({
+      // Make sure that your environment variables are filled out accordingly
+      mongoURL: process.env.MONGODB_URI as string,
+      secret: process.env.PAYLOAD_SECRET as string,
+      config,
+    });
+  }
+
+  try {
+    cached.client = await cached.promise;
+  } catch (e) {
+    cached.promise = null;
+    throw e;
+  }
+
+  return cached.client;
+};
+
+export default getPayloadClient;

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,4 @@
-import path from 'path';
 import next from 'next';
-import nextBuild from 'next/dist/build';
 import express from 'express';
 import payload from 'payload';
 import { config as dotenv } from 'dotenv';
@@ -17,24 +15,19 @@ const start = async () => {
     express: server,
   });
 
-  if (!process.env.NEXT_BUILD) {
-    const nextApp = next({ dev });
+  const nextApp = next({ dev });
 
-    const nextHandler = nextApp.getRequestHandler();
+  const nextHandler = nextApp.getRequestHandler();
 
-    server.get('*', (req, res) => nextHandler(req, res));
+  server.get('*', (req, res) => nextHandler(req, res));
 
-    nextApp.prepare().then(() => {
-      console.log('NextJS started'); // eslint-disable-line no-console
+  nextApp.prepare().then(() => {
+    console.log('NextJS started'); // eslint-disable-line no-console
 
-      server.listen(process.env.PORT, async () => {
-        console.log(`Server listening on ${process.env.PORT}...`); // eslint-disable-line no-console
-      });
+    server.listen(process.env.PORT, async () => {
+      console.log(`Server listening on ${process.env.PORT}...`); // eslint-disable-line no-console
     });
-  } else {
-    await nextBuild(path.join(__dirname, '../'));
-    process.exit();
-  }
+  });
 };
 
 start();

--- a/server.ts
+++ b/server.ts
@@ -25,18 +25,15 @@ const start = async () => {
     server.get('*', (req, res) => nextHandler(req, res));
 
     nextApp.prepare().then(() => {
-      console.log('NextJS started');
+      console.log('NextJS started'); // eslint-disable-line no-console
 
       server.listen(process.env.PORT, async () => {
-        console.log(`Server listening on ${process.env.PORT}...`);
+        console.log(`Server listening on ${process.env.PORT}...`); // eslint-disable-line no-console
       });
     });
   } else {
-    server.listen(process.env.PORT, async () => {
-      console.log('NextJS is now building...');
-      await nextBuild(path.join(__dirname, '../'));
-      process.exit();
-    });
+    await nextBuild(path.join(__dirname, '../'));
+    process.exit();
   }
 };
 


### PR DESCRIPTION
> Adjusts build scripts to accomodate static site generation (for the record this repo is currently **not** SSG, it is SSR via `getServerSideProps`). This change allows Payload to build and serve itself _before_ building Next.js so that statically generated pages have running APIs to hit for page data. Once finished, exits all processes.

Edit: migrates to a "payload client" which is booted up server-side and cached between requests. This allows us to not rely on a running instance of Payload to generate static sites. Instead, our static site functions boot Payload directly.